### PR TITLE
Color scheme improve

### DIFF
--- a/src/callbacks/cards.py
+++ b/src/callbacks/cards.py
@@ -44,7 +44,7 @@ def update_card(selected_entity):
 
     gdp_card = [
         dbc.CardHeader(f'GDP per Capita (USD)', style=header_style),
-        dbc.CardBody(f"{gdp_per_capita: ,.2f}", style=body_style)
+        dbc.CardBody(f"{gdp_per_capita: ,.0f}", style=body_style)
     ]
 
     population_card = [

--- a/src/callbacks/piecharts.py
+++ b/src/callbacks/piecharts.py
@@ -23,7 +23,7 @@ def update_energy_consumption_chart(selected_entity):
 
     # Specify legend titles and colors
     domain = ['Renewables', "Other"]
-    range_ = ['#4CBB17', '#C19A6B']
+    range_ = ['#76a787', '#bec6c7']
 
     # Plot pie chart
     energy_consumption_pie_chart = alt.Chart(pie_data).mark_arc(innerRadius=50).encode(
@@ -59,7 +59,7 @@ def update_electricty_generation_chart(selected_entity):
 
     # Specify legend titles and colors
     domain = ['Renewables', "Fossil Fuels", "Nuclear"]
-    range_ = ['#4CBB17', '#C19A6B', '#4682B4']
+    range_ = ['#76a787', '#cfbeb5', '#418ab8']
 
     # Plot pie chart
     electricity_consumption_pie_chart = alt.Chart(source).mark_arc(innerRadius=50).encode(

--- a/src/callbacks/worldmap.py
+++ b/src/callbacks/worldmap.py
@@ -22,33 +22,75 @@ def create_chart(variable, year_slider):
         fields=['Entity'], name='select_region', on='click'
     )
 
-    # Map data layer
-    non_missing_data = alt.Chart(gdf_filtered).mark_geoshape(
-        stroke='#666666',
-        strokeWidth=1
-    ).project(
-        'equalEarth'
-    ).encode(
-        color=alt.Color(variable, legend=alt.Legend(
-                                        orient='none', 
-                                        legendX=10, legendY=460, 
-                                        direction='horizontal', 
-                                        title=variable, 
-                                        gradientLength=300, 
-                                        labelLimit=500, 
-                                        titleLimit=500
-                                    )
-        ).scale(scheme="greens"),
-        tooltip=['Entity', variable],
-        stroke=alt.condition(hover, alt.value('white'), alt.value('#666666')), 
-        order=alt.condition(hover, alt.value(1), alt.value(0))
-    ).properties(
-        width=600,
-        height=500,
-    ).add_params(
-        hover,
-        click
-    )
+    # non_missing_data = alt.Chart(gdf_filtered).mark_geoshape(
+    #     stroke='#666666',
+    #     strokeWidth=1
+    # ).project(
+    #     'equalEarth'
+    # ).encode(
+    #     color=alt.Color(variable, legend=alt.Legend(
+    #                                     orient='none', 
+    #                                     legendX=10, legendY=460, 
+    #                                     direction='horizontal', 
+    #                                     title=variable, 
+    #                                     gradientLength=300, 
+    #                                     labelLimit=500, 
+    #                                     titleLimit=500
+    #                                 )
+    #     ).scale(scheme="greens"),
+    #     tooltip=['Entity', variable],
+    #     stroke=alt.condition(hover, alt.value('white'), alt.value('#666666')), 
+    #     order=alt.condition(hover, alt.value(1), alt.value(0))
+    # ).properties(
+    #     width=600,
+    #     height=500,
+    # ).add_params(
+    #     hover,
+    #     click
+    # )
+
+    def plot_chart(variable, color_scheme):
+        return alt.Chart(gdf_filtered).mark_geoshape(
+            stroke='#666666',
+            strokeWidth=1
+        ).project(
+            'equalEarth'
+        ).encode(
+            color=alt.Color(variable, legend=alt.Legend(
+                                            orient='none', 
+                                            legendX=10, legendY=460, 
+                                            direction='horizontal', 
+                                            title=variable, 
+                                            gradientLength=300, 
+                                            labelLimit=500, 
+                                            titleLimit=500
+                                        )
+            ).scale(scheme=color_scheme),
+            tooltip=['Entity', variable],
+            stroke=alt.condition(hover, alt.value('white'), alt.value('#666666')),
+            order=alt.condition(hover, alt.value(1), alt.value(0))
+        ).properties(
+            width=600,
+            height=500,
+        ).add_params(
+            hover,
+            click
+        )
+
+    color_schemes = {
+        'Electricity from fossil fuels (TWh)': 'browns',
+        'Electricity from nuclear (TWh)': 'blues',
+        'Financial flows to developing countries (US $)': 'purples'
+    }
+
+    # Use a default color scheme if the variable is not in the dictionary
+    default_color_scheme = 'greens'
+
+    # Determine the color scheme based on the variable
+    selected_color_scheme = color_schemes.get(variable, default_color_scheme)
+
+    # Create the chart with the selected color scheme
+    non_missing_data = plot_chart(variable, selected_color_scheme)
 
     # Map background layer
     background_map = alt.Chart(world).mark_geoshape(color="lightgrey")


### PR DESCRIPTION
Changes as follows:
1. Adjust arc chart colours: not beige also fossil fuel does not equal Other 
2. get rid of two decimals for the GDP cards.
3. An additional improvement on world map color scheme. The green scheme does not suitable for all variables, e.g., darker green indicating higher fossil fuels does not make sense, thus, I use multiple color schemes to represent different metrics. see below:
```
color_schemes = {
      'Electricity from fossil fuels (TWh)': 'browns',
      'Electricity from nuclear (TWh)': 'blues',
      'Financial flows to developing countries (US $)': 'purples'  
}
default_color_scheme = 'greens'
```